### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.7.1-alpine
 
-RUN apk --update add git ca-certificates && rm -rf /var/cache/apk/*
+RUN apk --update add git ca-certificates curl && rm -rf /var/cache/apk/*
 
 ARG VERSION
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ services:
 ```
 
 
-Added CURL to perform health checks from insdide the container
+Added CURL to perform health checks from inside the container
 eg.:
 ```
     healthcheck:

--- a/README.md
+++ b/README.md
@@ -15,14 +15,33 @@ CF_HOST=xx.yy.com CF_API_KEY=xxxxx -e CF_API_EMAIL=your@email.com go run cmd/clo
 docker run -e CF_HOST=xx.yy.com -e CF_API_KEY=xxxxx -e CF_API_EMAIL=your@email.com arkan/cloudflare-ddns:latest
 ```
 
-## unRAID
+## Compose v3 
+```
+version: '3'
+services:
+  dns:
+    image: berndinox/cloudflare-ddns:latest
+    environment:
+      - CF_HOST=${DOMAIN}
+      - CF_API_KEY=${KEY}
+      - CF_API_EMAIL=${MAIL}
+    deploy:
+      replicas: 1
+```
 
-You can use my [unraid-templates](https://github.com/arkan/unraid-templates).
+
+Added CURL to perform health checks from insdide the container
+eg.:
+```
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://${DOMAIN}"]
+      interval: 20s
+      timeout: 10s
+      retries: 3
+```
 
 
-#Copyright
-
+Soure:
 Copyright © 2016 Florian Bertholin
-
 See the [LICENSE](./LICENSE) (MIT) file for more details.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ CF_HOST=xx.yy.com CF_API_KEY=xxxxx -e CF_API_EMAIL=your@email.com go run cmd/clo
 ## Docker
 
 ```
-docker run -e CF_HOST=xx.yy.com -e CF_API_KEY=xxxxx -e CF_API_EMAIL=your@email.com arkan/cloudflare-ddns:latest
+docker run -e CF_HOST=xx.yy.com -e CF_API_KEY=xxxxx -e CF_API_EMAIL=your@email.com berndinox/cloudflare-ddns:latest
 ```
 
 ## Compose v3 


### PR DESCRIPTION
Add CURL
---------------------------------------------
Adding Curl to be able to perform health checks within docker-compose.
Why it's usefull:

```
version: '3'

services:

  wordpress:
      image: wordpress
      volumes:
        - html:/var/www/html
      networks:
        proxy:
          aliases:
            - wordpress
        default:

  mariadb:
      image: mariadb
      volumes:
        - mysql:/var/lib/mysql
      deploy:
        replicas: 1

  DNS:
      image: arkan/cloudflare-ddns:latest
      environment:
        - CF_HOST=${DOMAIN}
        - CF_API_KEY=${KEY}
        - CF_API_EMAIL=${EMAIL}
      deploy:
        replicas: 1
      healthcheck:
        test: ["CMD", "curl", "-f", "https://${DOMAIN}"]
        interval: 10s
        timeout: 5s
        retries: 3
```

DNS is running on host 1, so DNS is updated to the IP of Host 1. Host 1 got's an issue and the site is no longer available. DNS fails cause the health check fails. The DNS Container (hoepfully) gets spawnd on another machine and updates the DNS with the new IP.